### PR TITLE
Fix: Update pom.xml to fix Cx3718d76a-e8e1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
         <!-- DEPENDENCIES -->
         <annotations.version>24.0.1</annotations.version>
-        <jetty.version>11.0.15</jetty.version>
+        <jetty.version>12.0.0</jetty.version>
         <jackson.version>2.15.0</jackson.version>
         <jackson.databind.version>2.15.0</jackson.databind.version>
         <brotli4j.version>1.11.0</brotli4j.version>


### PR DESCRIPTION
jetty-xml 11.0.15 is vulnerable Cx3718d76a-e8e1 Improper Restriction of XML External Entity Reference vulnerability with low severity found
So I think the version of jetty should be updated